### PR TITLE
Use subpath exports in addition to module/main

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
   "main": "dist/main/index.js",
   "typings": "dist/main/index.d.ts",
   "module": "dist/module/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/module/index.js",
+      "require": "./dist/main/index.js"
+    }
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
There is a scenario in which we get the error

> Error: Unexpected content type in insert operation

when using slate-yjs and yjs in next.

Namely, when going by the "module" definition, the source of the request is considered, as opposed to the target, which you get by going by subpath exports. So what happens is, the source (webpack) requires slate-yjs, but since slate-yjs has a "module" definition it goes to the ESM version of yjs, and we get 2 yjs instances - ESM and CJS - and the error.

By using the subpath exports, it will use CJS all the way and the error goes away.

If anything, using subpath exports matches what yjs is doing.

It is a bit tricky to explain, I hope this made sense.