### PR TITLE
Fix selection moving bug

### DIFF
--- a/src/applyToSlate/arrayEvent.ts
+++ b/src/applyToSlate/arrayEvent.ts
@@ -3,6 +3,7 @@ import invariant from 'tiny-invariant';
 import * as Y from 'yjs';
 import { SyncElement } from '../model';
 import { toSlateNode, toSlatePath } from '../utils/convert';
+import { withoutNormalizingAndSelectionMod } from './util';
 
 /**
  * Applies a Yjs Array event to a Slate editor.
@@ -16,7 +17,7 @@ export default function applyArrayEvent(
   let offset = 0;
   const targetPath = toSlatePath(event.path);
 
-  Editor.withoutNormalizing(editor, () => {
+  withoutNormalizingAndSelectionMod(editor, () => {
     event.changes.delta.forEach((delta) => {
       if ('retain' in delta) {
         offset += delta.retain ?? 0;

--- a/src/applyToSlate/mapEvent.ts
+++ b/src/applyToSlate/mapEvent.ts
@@ -2,6 +2,7 @@ import { Editor, Transforms } from 'slate';
 import * as Y from 'yjs';
 import { SyncElement } from '../model';
 import { toSlatePath } from '../utils/convert';
+import { withoutNormalizingAndSelectionMod } from './util';
 
 /**
  * Applies a Yjs map event to a Slate editor.
@@ -31,7 +32,7 @@ export default function applyMapEvent(
       {}
     );
 
-  Editor.withoutNormalizing(editor, () => {
+  withoutNormalizingAndSelectionMod(editor, () => {
     if (removedProperties.length > 0) {
       Transforms.unsetNodes(editor, removedProperties, { at: targetPath });
     }

--- a/src/applyToSlate/textEvent.ts
+++ b/src/applyToSlate/textEvent.ts
@@ -2,6 +2,7 @@ import { Editor, Transforms } from 'slate';
 import invariant from 'tiny-invariant';
 import * as Y from 'yjs';
 import { toSlatePath } from '../utils/convert';
+import { withoutNormalizingAndSelectionMod } from './util';
 
 /**
  * Applies a Yjs Text event to a slate editor.
@@ -15,7 +16,7 @@ export default function applyTextEvent(
   const targetPath = toSlatePath(event.path);
   let offset = 0;
 
-  Editor.withoutNormalizing(editor, () => {
+  withoutNormalizingAndSelectionMod(editor, () => {
     event.changes.delta.forEach((delta) => {
       if ('retain' in delta) {
         offset += delta.retain ?? 0;

--- a/src/applyToSlate/util.ts
+++ b/src/applyToSlate/util.ts
@@ -1,10 +1,17 @@
-import { Editor, Transforms } from 'slate';
+import { Editor } from 'slate';
 
 export const withoutSelectionMod = (editor: Editor, cb: () => any): void => {
-  const { selection } = editor;
+  const { apply } = editor;
+  // eslint-disable-next-line no-param-reassign
+  editor.apply = (op) => {
+    if (op.type === 'set_selection') return;
+
+    apply(op);
+  };
   cb();
-  if (selection) Transforms.select(editor, selection);
-  else Transforms.deselect(editor);
+
+  // eslint-disable-next-line no-param-reassign
+  editor.apply = apply;
 };
 
 export const withoutNormalizingAndSelectionMod = (

--- a/src/applyToSlate/util.ts
+++ b/src/applyToSlate/util.ts
@@ -1,0 +1,19 @@
+import { Editor, Transforms } from 'slate';
+
+export const withoutSelectionMod = (editor: Editor, cb: () => any): void => {
+  const { selection } = editor;
+  cb();
+  if (selection) Transforms.select(editor, selection);
+  else Transforms.deselect(editor);
+};
+
+export const withoutNormalizingAndSelectionMod = (
+  editor: Editor,
+  cb: () => any
+): void => {
+  Editor.withoutNormalizing(editor, () => {
+    withoutSelectionMod(editor, () => {
+      cb();
+    });
+  });
+};


### PR DESCRIPTION
Fixes https://github.com/BitPhinix/slate-yjs/issues/226

When applying remote yjs events to a Slate document, slate-yjs uses the `Transforms` slate module with calls like Transforms.insertText, Transforms.setNodes, etc. These methods update the local user's selection state after doing the transformation. This is not what we want when applying remote operations; the transformations should not affect the local user's selection state.

This PR ignores "set_selection" operations while Yjs events are being applied to a Slate editor. As seen in the video linked in the comments below, this will preserve the intended selection location of the local user, even as changes happen on the same line or other lines from a remote user.