### PR TITLE
Fix selection lag

### DIFF
--- a/src/plugin/cursorEditor.ts
+++ b/src/plugin/cursorEditor.ts
@@ -30,8 +30,7 @@ export const CursorEditor = {
       absolutePositionToRelativePosition(sharedType, selection.focus);
 
     const awareness = CursorEditor.awareness(editor);
-    awareness.setLocalStateField('anchor', anchor);
-    awareness.setLocalStateField('focus', focus);
+    awareness.setLocalState({ ...awareness.getLocalState(), anchor, focus });
   },
 };
 


### PR DESCRIPTION
anchor and focus are using separate awareness updates.

So, when updating them, first comes anchor then focus, meaning at one point we have a new anchor and the old focus. This leads to erroneous selections in the editor, and possibly crashes, as the selection is invalid during that window.

It is only noticeable when a network lag is introduced, so the example doesn't show it.