### PR TITLE
chore(deps): update y-protocols to ^1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6520,6 +6520,7 @@
       "version": "0.2.41",
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.41.tgz",
       "integrity": "sha512-lZ0I6N81tIDgoPIlUTRhb6mNjPsG5BXIbaK/UbtjakcYnfR+O64bKtIrLXDDnfd7nAo4vpGeZ0mPzbTsNTREcg==",
+      "dev": true,
       "requires": {
         "isomorphic.js": "^0.2.4"
       }
@@ -12086,11 +12087,21 @@
       "dev": true
     },
     "y-protocols": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.4.tgz",
-      "integrity": "sha512-5/Hd6DJ5Y2SlbqLIKq86BictdOS0iAcWJZCVop8MKqx0XWwA+BbMn4538n4Z0CGjFMUGnG1kGzagk3BKGz5SvQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.5.tgz",
+      "integrity": "sha512-Wil92b7cGk712lRHDqS4T90IczF6RkcvCwAD0A2OPg+adKmOe+nOiT/N2hvpQIWS3zfjmtL4CPaH5sIW1Hkm/A==",
       "requires": {
-        "lib0": "^0.2.35"
+        "lib0": "^0.2.42"
+      },
+      "dependencies": {
+        "lib0": {
+          "version": "0.2.42",
+          "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.42.tgz",
+          "integrity": "sha512-8BNM4MiokEKzMvSxTOC3gnCBisJH+jL67CnSnqzHv3jli3pUvGC8wz+0DQ2YvGr4wVQdb2R2uNNPw9LEpVvJ4Q==",
+          "requires": {
+            "isomorphic.js": "^0.2.4"
+          }
+        }
       }
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "tiny-invariant": "1.1.0",
-    "y-protocols": "^1.0.2"
+    "y-protocols": "^1.0.5"
   },
   "peerDependencies": {
     "react": "^17.0.1",


### PR DESCRIPTION
This applies to NPM users, as it bumps the package-lock.json