### PR TITLE
feat: expose toSyncElement function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
   withYjs,
   YjsEditor,
 } from './plugin';
-import { toSharedType, toSlateDoc } from './utils';
+import { toSharedType, toSlateDoc, toSyncElement } from './utils';
 
 export {
   SharedType,
@@ -21,6 +21,7 @@ export {
   YjsEditor,
   toSharedType,
   toSlateDoc,
+  toSyncElement,
   translateYjsEvent,
   applyYjsEvents,
   applySlateOps,


### PR DESCRIPTION
Allow clients to convert slate nodes to SyncElements in order to customize inserting SyncElements to
a doc.

I've kept with the format as it was in index.ts, although it might be a good idea to re-export directly, i.e:

```
export { toSharedType, toSlateDoc, toSyncElement } from './utils';
```