### PR TITLE
Fix normalizations not applied

### DIFF
--- a/src/applyToSlate/index.ts
+++ b/src/applyToSlate/index.ts
@@ -30,8 +30,6 @@ export function translateYjsEvent(
 
 /**
  * Applies multiple yjs events to a slate editor.
- *
- * @param event
  */
 export function applyYjsEvents(editor: Editor, events: Y.YEvent[]): void {
   Editor.withoutNormalizing(editor, () => {

--- a/src/applyToYjs/index.ts
+++ b/src/applyToYjs/index.ts
@@ -35,20 +35,18 @@ export function applySlateOp(
 
 /**
  * Applies slate operations to a SharedType
- *
- * @param sharedType
- * @param op
  */
 export default function applySlateOps(
   sharedType: SharedType,
-  ops: Operation[]
+  ops: Operation[],
+  origin: unknown
 ): SharedType {
   invariant(sharedType.doc, 'Shared type without attached document');
 
   if (ops.length > 0) {
     sharedType.doc.transact(() => {
       ops.forEach((op) => applySlateOp(sharedType, op));
-    });
+    }, origin);
   }
 
   return sharedType;

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -6,6 +6,8 @@ export type SyncElement = Y.Map<any>;
 export type SharedType = Y.Array<SyncElement>;
 export type SyncNode = SharedType | SyncElement;
 
+export const slateYjsSymbol = Symbol('slate-yjs');
+
 export interface Cursor extends Range {
   data: {
     [key: string]: unknown;

--- a/src/plugin/useCursors.ts
+++ b/src/plugin/useCursors.ts
@@ -38,7 +38,7 @@ export const useCursors = (
         })
         .filter((cursor) => cursor.anchor && cursor.focus);
 
-      setCursorData((newCursorData as unknown) as Cursor[]);
+      setCursorData(newCursorData as unknown as Cursor[]);
     });
   }, [editor]);
 

--- a/test/collaboration.test.ts
+++ b/test/collaboration.test.ts
@@ -345,8 +345,8 @@ describe('slate operations propagate between editors', () => {
   tests.forEach(([testName, input, ...cases]) => {
     it(`${testName}`, async () => {
       // Create two editors.
-      const src = createTestEditor();
-      const dst = createTestEditor();
+      const src = await createTestEditor();
+      const dst = await createTestEditor();
 
       // Set initial state for src editor, propagate changes to dst editor.
       TestEditor.applyTransform(

--- a/test/concurrent.test.ts
+++ b/test/concurrent.test.ts
@@ -173,8 +173,8 @@ const tests: Test[] = [
 
 const runOneTest = async (ti: Test, tj: Test) => {
   // Create two editors.
-  const ei = createTestEditor();
-  const ej = createTestEditor();
+  const ei = await createTestEditor();
+  const ej = await createTestEditor();
 
   // Set initial state for 1st editor, propagate changes to 2nd.
   TestEditor.applyTransform(

--- a/test/plugin/yjsEditor.test.ts
+++ b/test/plugin/yjsEditor.test.ts
@@ -1,0 +1,76 @@
+import { Node, Element } from 'slate';
+import { toSlateDoc, toSyncElement, YjsEditor } from '../../src';
+import { createTestEditor } from '../utils';
+
+// onChange fires in the next tick, see slate createEditor
+async function waitForSlateOnChangeAround(callback: () => void) {
+  await callback();
+  await Promise.resolve();
+}
+
+describe('YjsEditor', () => {
+  let yjsEditor: YjsEditor;
+
+  const initialValue: Node[] = [
+    { type: 'paragraph', children: [{ text: '' }] },
+  ];
+
+  const newElement: Element = {
+    type: 'paragraph',
+    children: [{ text: 'new' }],
+  };
+
+  beforeEach(async () => {
+    yjsEditor = await createTestEditor(initialValue);
+  });
+
+  it('should sync changes to the shared type with slate', async () => {
+    await waitForSlateOnChangeAround(() =>
+      yjsEditor.sharedType.push([toSyncElement(newElement)])
+    );
+
+    expect(yjsEditor.children).toEqual<Node[]>([...initialValue, newElement]);
+    // make sure we didn't erroneously add elements to the shared type - can happen
+    // if the observer we have for it applies "local" events
+    expect(toSlateDoc(yjsEditor.sharedType)).toEqual<Node[]>(
+      yjsEditor.children
+    );
+  });
+
+  it('should apply slate operations to yjs', async () => {
+    await waitForSlateOnChangeAround(() => yjsEditor.insertNode(newElement));
+
+    expect(toSlateDoc(yjsEditor.sharedType)).toEqual<Node[]>([
+      ...initialValue,
+      newElement,
+    ]);
+  });
+
+  it('should apply slate normalizations to yjs', async () => {
+    const normalization: Element = {
+      type: 'paragraph',
+      children: [{ text: 'some normalization' }],
+    };
+
+    const { normalizeNode } = yjsEditor;
+
+    yjsEditor.normalizeNode = (entry) => {
+      const isNewElement = entry[0].text === newElement.children[0].text;
+      if (isNewElement) {
+        yjsEditor.insertNode(normalization);
+      }
+
+      normalizeNode(entry);
+    };
+
+    await waitForSlateOnChangeAround(() =>
+      yjsEditor.sharedType.push([toSyncElement(newElement)])
+    );
+
+    expect(toSlateDoc(yjsEditor.sharedType)).toEqual<Node[]>([
+      ...initialValue,
+      newElement,
+      normalization,
+    ]);
+  });
+});

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -49,7 +49,7 @@ export function wait(ms = 0): Promise<void> {
   return new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
-export function createTestEditor(value?: Node[]): TestEditor {
+export async function createTestEditor(value?: Node[]): Promise<TestEditor> {
   const doc = new Y.Doc();
   const syncType = doc.getArray<SyncElement>('content');
 
@@ -57,5 +57,10 @@ export function createTestEditor(value?: Node[]): TestEditor {
     toSharedType(syncType, value);
   }
 
-  return withTest(withYjs(createEditor(), syncType));
+  const editor = withTest(withYjs(createEditor(), syncType));
+
+  // wait for value sync
+  await wait();
+
+  return editor;
 }


### PR DESCRIPTION
When applying YJS events coming from remote (basically through the shared type), all operations that are triggered as part of this process should be applied as well. An example of such operations are normalizations - if we don't apply normalizations to the shared type, slate and YJS will be out of sync and eventually an error will be thrown. I have identified a couple of reasons why normalizations would be triggered on the receiving side:

* other side has different normalization rules (stale client), so the events we get lead to a normalization run
* applying changes to the shared type from editor.sharedType, as opposed to the changes coming from slate

To note: i have been messing about naming these operations without success, I've settled on isRemoteEvent and isProcessedOperation, however i am open to changing those.

[I have introduced a test suite which can be ran against master to confirm the issue as well.](https://github.com/livingspec/slate-yjs/blob/a726ef08e8c5500117fddad43f3c1048cd2b8431/test/plugin/yjsEditor.test.ts)

Careful applying the test to master, it needs an explicit synchronize value call in the beforeEach ([something I've resolved in the PR by waiting for the sync before continuing the tests](https://github.com/BitPhinix/slate-yjs/commit/8a83780f9f44174315184e48d8f34abcccb9bf5c)), like so:

```
beforeEach(async () => {
  (yjsEditor = await createTestEditor(initialValue));
  await YjsEditor.synchronizeValue(yjsEditor);
});
```