### PR TITLE
Optional synchronize value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   useCursors,
   withCursor,
   withYjs,
+  WithYjsOptions,
   YjsEditor,
 } from './plugin';
 import { toSharedType, toSlateDoc, toSyncElement } from './utils';
@@ -18,6 +19,7 @@ export {
   useCursors,
   withCursor,
   withYjs,
+  WithYjsOptions,
   YjsEditor,
   toSharedType,
   toSlateDoc,

--- a/src/plugin/yjsEditor.ts
+++ b/src/plugin/yjsEditor.ts
@@ -100,7 +100,7 @@ function applyRemoteYjsEvents(editor: YjsEditor, events: Y.YEvent[]): void {
 export function withYjs<T extends Editor>(
   editor: T,
   sharedType: SharedType,
-  { synchronizeValue }: WithYjsOptions = { synchronizeValue: true }
+  { synchronizeValue = true }: WithYjsOptions = {}
 ): T & YjsEditor {
   const e = editor as T & YjsEditor;
 
@@ -131,6 +131,6 @@ export function withYjs<T extends Editor>(
   return e;
 }
 
-export interface WithYjsOptions {
+export type WithYjsOptions = {
   synchronizeValue?: boolean;
-}
+};

--- a/src/plugin/yjsEditor.ts
+++ b/src/plugin/yjsEditor.ts
@@ -99,7 +99,8 @@ function applyRemoteYjsEvents(editor: YjsEditor, events: Y.YEvent[]): void {
 
 export function withYjs<T extends Editor>(
   editor: T,
-  sharedType: SharedType
+  sharedType: SharedType,
+  { synchronizeValue }: WithYjsOptions = { synchronizeValue: true }
 ): T & YjsEditor {
   const e = editor as T & YjsEditor;
 
@@ -107,7 +108,9 @@ export function withYjs<T extends Editor>(
   SHARED_TYPES.set(editor, sharedType);
   LOCAL_OPERATIONS.set(editor, new Set());
 
-  setTimeout(() => YjsEditor.synchronizeValue(e), 0);
+  if (synchronizeValue) {
+    setTimeout(() => YjsEditor.synchronizeValue(e), 0);
+  }
 
   sharedType.observeDeep((events) => applyRemoteYjsEvents(e, events));
 
@@ -126,4 +129,8 @@ export function withYjs<T extends Editor>(
   };
 
   return e;
+}
+
+export interface WithYjsOptions {
+  synchronizeValue?: boolean;
 }

--- a/test/plugin/yjsEditor.test.ts
+++ b/test/plugin/yjsEditor.test.ts
@@ -19,6 +19,20 @@ describe('YjsEditor', () => {
     yjsEditor = await createTestEditor(initialValue);
   });
 
+  describe('initial editor value sync', () => {
+    it('should set editor.children to the value of the shared type', async () => {
+      expect(yjsEditor.children).toEqual<Node[]>(initialValue);
+    });
+
+    it('should be optional', async () => {
+      yjsEditor = await createTestEditor(initialValue, {
+        synchronizeValue: false,
+      });
+
+      expect(yjsEditor.children).toEqual<Node[]>([]);
+    });
+  });
+
   describe('shared type <=> slate sync', () => {
     const newElement: Element = {
       type: 'paragraph',

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -8,6 +8,7 @@ import {
   withYjs,
 } from '../src';
 import { TestEditor, withTest } from './testEditor';
+import { WithYjsOptions } from '../src/plugin';
 
 export function createText(text = ''): Text {
   return {
@@ -49,7 +50,10 @@ export function wait(ms = 0): Promise<void> {
   return new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
 
-export async function createTestEditor(value?: Node[]): Promise<TestEditor> {
+export async function createTestEditor(
+  value?: Node[],
+  options?: WithYjsOptions
+): Promise<TestEditor> {
   const doc = new Y.Doc();
   const syncType = doc.getArray<SyncElement>('content');
 
@@ -57,7 +61,7 @@ export async function createTestEditor(value?: Node[]): Promise<TestEditor> {
     toSharedType(syncType, value);
   }
 
-  const editor = withTest(withYjs(createEditor(), syncType));
+  const editor = withTest(withYjs(createEditor(), syncType, options));
 
   // wait for value sync
   await wait();


### PR DESCRIPTION
Based on: https://github.com/BitPhinix/slate-yjs/pull/282/checks?check_run_id=3031625506, so should be either merged after that one, or we can merge just this one in case both changes are good to go.

Given a scenario where the current value is pulled in asynchronously, after the editor is setup, the sync step is firing while shared type is empty. It would be a good thing if we could manually sync the shared type value to the editor until we get the data, and in the meantime keep the shared type empty and not resort to temporary values.

As an example of how we use the flag:

```
const doc = Doc();

const sharedType = doc.getArray('children');

const yjsEditor = withCursor(
  withYjs(editor, sharedType, { synchronizeValue: false }),
  socketIoClient.awareness,
);

// ...later

await new Promise<void>(resolve => {
  socketIoClient.onSync = () => {
    YjsEditor.synchronizeValue(yjsEditor);
    resolve();
  };

  socketIoClient.connect();
});
```