### PR TITLE
fix(setNode): improve the setNode method

### DIFF
--- a/src/applyToYjs/node/setNode.ts
+++ b/src/applyToYjs/node/setNode.ts
@@ -22,5 +22,12 @@ export default function setNode(
     node.set(key, value);
   });
 
+  Object.entries(op.properties).forEach(([key]) => {
+    // eslint-disable-next-line no-prototype-builtins
+    if (!op.newProperties.hasOwnProperty(key)) {
+      node.delete(key);
+    }
+  });
+
   return doc;
 }


### PR DESCRIPTION
Hi, @BitPhinix .

When I use slate-yjs, I ran into a problem.

I add **rowspan** to properties when merging the table：
![image](https://user-images.githubusercontent.com/44698191/133202696-cd983fab-9b83-4d5f-8bb1-5daa4f91ed6c.png)

And when I perform the undo operation, the operation is as follows：
![image](https://user-images.githubusercontent.com/44698191/133202656-0523b9f3-08e7-4868-8b22-82969ba0355d.png)

There are no properties in `newProperties` at this time.

 I found that the setNode method does not handle the situation that when the properties in `properties` do not exist in `newProperties`. The result is that other clients cannot delete the **rowspan** attribute.

I think properties that were previously defined, but are now missing, must be deleted.

Please review this PR and let me know what you think.