### PR TITLE
fix: export slateYjsOriginSymbol

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
 import { applyYjsEvents, translateYjsEvent } from './applyToSlate';
 import applySlateOps from './applyToYjs';
-import { SharedType, SyncElement, SyncNode } from './model';
+import {
+  SharedType,
+  SyncElement,
+  SyncNode,
+  slateYjsOriginSymbol,
+} from './model';
 import {
   CursorEditor,
   useCursors,
@@ -27,4 +32,5 @@ export {
   translateYjsEvent,
   applyYjsEvents,
   applySlateOps,
+  slateYjsOriginSymbol,
 };

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -6,7 +6,9 @@ export type SyncElement = Y.Map<any>;
 export type SharedType = Y.Array<SyncElement>;
 export type SyncNode = SharedType | SyncElement;
 
-export const slateYjsSymbol = Symbol('slate-yjs');
+export const slateYjsOriginSymbol = Symbol(
+  'Denotes that an event originated from slate-yjs'
+);
 
 export interface Cursor extends Range {
   data: {

--- a/src/plugin/yjsEditor.ts
+++ b/src/plugin/yjsEditor.ts
@@ -3,7 +3,7 @@ import invariant from 'tiny-invariant';
 import * as Y from 'yjs';
 import { applyYjsEvents } from '../applyToSlate';
 import applySlateOps from '../applyToYjs';
-import { SharedType, slateYjsSymbol } from '../model';
+import { SharedType, slateYjsOriginSymbol } from '../model';
 import { toSlateDoc } from '../utils';
 
 const IS_REMOTE: WeakSet<Editor> = new WeakSet();
@@ -77,7 +77,7 @@ function applyLocalOperations(editor: YjsEditor): void {
   applySlateOps(
     YjsEditor.sharedType(editor),
     Array.from(editorLocalOperations),
-    slateYjsSymbol
+    slateYjsOriginSymbol
   );
 
   editorLocalOperations.clear();
@@ -91,7 +91,9 @@ function applyRemoteYjsEvents(editor: YjsEditor, events: Y.YEvent[]): void {
     YjsEditor.asRemote(editor, () =>
       applyYjsEvents(
         editor,
-        events.filter((event) => event.transaction.origin !== slateYjsSymbol)
+        events.filter(
+          (event) => event.transaction.origin !== slateYjsOriginSymbol
+        )
       )
     )
   );


### PR DESCRIPTION
Rename `slateYjsSymbol` to `slateYjsOriginSymbol` and export. The reason for the rename is because the symbol is used to represent the fact that events originate from slate-yjs.

fixes #303