### PR TITLE
chore(core): don't autoconnect by default

### DIFF
--- a/.changeset/warm-cars-sparkle.md
+++ b/.changeset/warm-cars-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@slate-yjs/core': patch
+---
+
+don't autoConnect by default

--- a/docs/walkthroughs/collaboration-hocuspocus.md
+++ b/docs/walkthroughs/collaboration-hocuspocus.md
@@ -54,6 +54,7 @@ export function Editor() {
       new HocuspocusProvider({
         url: 'ws://127.0.0.1:1234',
         name: 'slate-yjs-demo',
+        connect: false,
       }),
     []
   );
@@ -63,9 +64,16 @@ export function Editor() {
     return withReact(withYHistory(withYjs(createEditor(), sharedType)));
   }, [provider.document]);
 
-  // Disconnect YjsEditor on unmount in order to free up resources
-  useEffect(() => () => YjsEditor.disconnect(editor), [editor]);
-  useEffect(() => () => provider.disconnect(), [provider]);
+  // Connect editor and provider in useEffect to comply with concurrent mode
+  // requirements.
+  useEffect(() => {
+    provider.connect();
+    return () => provider.disconnect();
+  }, [provider]);
+  useEffect(() => {
+    YjsEditor.connect(editor);
+    return () => YjsEditor.disconnect(editor);
+  }, [editor]);
 
   return (
     <Slate value={value} onChange={setValue} editor={editor}>

--- a/docs/walkthroughs/installation.md
+++ b/docs/walkthroughs/installation.md
@@ -143,8 +143,12 @@ const Editor = () => {
   const editor = useMemo(() => withYjs(withReact(createEditor()), sharedType), [])
   const [value, setValue] = useState([])
 
-  // Disconnect the binding on component unmount in order to free up resources
-  useEffect(() => () => YjsEditor.disconnect(editor), [])
+
+  // Connect editor in useEffect to comply with concurrent mode requirements.
+  useEffect(() => {
+    YjsEditor.connect(editor);
+    return () => YjsEditor.disconnect(editor);
+  }, [editor]);
 
   return (
     <Slate

--- a/packages/core/src/plugins/withYjs.ts
+++ b/packages/core/src/plugins/withYjs.ts
@@ -163,7 +163,7 @@ export function withYjs<T extends Editor>(
   {
     localOrigin,
     positionStorageOrigin,
-    autoConnect = true,
+    autoConnect = false,
   }: WithYjsOptions = {}
 ): T & YjsEditor {
   const e = editor as T & YjsEditor;

--- a/packages/core/test/withTestingElements.ts
+++ b/packages/core/test/withTestingElements.ts
@@ -37,7 +37,7 @@ export async function withTestingElements(
     sharedType.applyDelta(slateNodesToInsertDelta(editor.children));
   }
 
-  const e = withYjs(editor, sharedType);
+  const e = withYjs(editor, sharedType, { autoConnect: true });
 
   // Wait for editor to be initialized
   await wait();

--- a/support/fixtures.ts
+++ b/support/fixtures.ts
@@ -42,7 +42,6 @@ export function fixtures<P extends any[]>(...args: P) {
       ) {
         const name = basename(file, extname(file));
 
-        // This needs to be a non-arrow function to use `this.skip()`.
         it(`${name} `, async () => {
           const module = await import(p);
 


### PR DESCRIPTION
Since auto-connect is a side effect, it should be triggered by a useEffect (otherwise it'll break in strict mode and future versions of react). The current docs encourage the use of auto-connect in react, which should not be the case.

Fixes: #331