### PR TITLE
Throw error in non-static connect call if editor is already connected

### DIFF
--- a/.changeset/early-flowers-begin.md
+++ b/.changeset/early-flowers-begin.md
@@ -1,0 +1,5 @@
+---
+'@slate-yjs/core': patch
+---
+
+Throw error in non-static connect call if editor is already connected

--- a/packages/core/src/plugins/withYjs.ts
+++ b/packages/core/src/plugins/withYjs.ts
@@ -84,10 +84,6 @@ export const YjsEditor = {
   },
 
   connect(editor: YjsEditor): void {
-    if (YjsEditor.connected(editor)) {
-      throw new Error('already connected');
-    }
-
     editor.connect();
   },
 
@@ -206,6 +202,10 @@ export function withYjs<T extends Editor>(
   }
 
   e.connect = () => {
+    if (YjsEditor.connected(e)) {
+      throw new Error('already connected');
+    }
+
     sharedRoot.observeDeep(handleYEvents);
     const content = yTextToSlateElement(e.sharedRoot);
     e.children = content.children;


### PR DESCRIPTION
Pretty self-explanatory. While it's not recommended to call `editor.connect` directly, a lot of users do which might result in the YjsEditor attaching its handlers twice