### PR TITLE
use editor.sharedRoot in connect/disconnect

### DIFF
--- a/.changeset/unlucky-plums-repair.md
+++ b/.changeset/unlucky-plums-repair.md
@@ -1,0 +1,5 @@
+---
+"@slate-yjs/core": patch
+---
+
+use editor.sharedRoot in connect/disconnect

--- a/packages/core/src/plugins/withYjs.ts
+++ b/packages/core/src/plugins/withYjs.ts
@@ -206,7 +206,7 @@ export function withYjs<T extends Editor>(
       throw new Error('already connected');
     }
 
-    sharedRoot.observeDeep(handleYEvents);
+    e.sharedRoot.observeDeep(handleYEvents);
     const content = yTextToSlateElement(e.sharedRoot);
     e.children = content.children;
     CONNECTED.add(e);
@@ -219,7 +219,7 @@ export function withYjs<T extends Editor>(
     }
 
     YjsEditor.flushLocalChanges(e);
-    sharedRoot.unobserveDeep(handleYEvents);
+    e.sharedRoot.unobserveDeep(handleYEvents);
     CONNECTED.delete(e);
   };
 


### PR DESCRIPTION
Hi!

First of all I wanna thank you for the great library!

That PR fixes subscribing for events on actual `editor.sharedRoot` that could be replaced/overwritten by developers in their own plugins.

In some use cases there should be possible to replace/overwrite `editor.sharedRoot` in your own plugins, e.g. to be able to initialize `Y.Doc`/`sharedRoot` in your own plugins  (lazily in sync or even async way), e.g. custom plugin that fetches initial `StateVector` from backend and after that to call `editor.connect()` . But when I overwrite `editor.sharedRoot` in my own plugin and call `editor.connect()` it continue subscribing to initial `sharedRoot` from `withYjs` plugin  argument.