### PR TITLE
fix: use editor properties in plugin methods

### DIFF
--- a/.changeset/spicy-apricots-knock.md
+++ b/.changeset/spicy-apricots-knock.md
@@ -1,0 +1,5 @@
+---
+"@slate-yjs/core": patch
+---
+
+fix: use editor properties in plugin methods

--- a/packages/core/src/plugins/withCursors.ts
+++ b/packages/core/src/plugins/withCursors.ts
@@ -181,12 +181,12 @@ export function withCursors<
   };
 
   e.sendCursorPosition = (range) => {
-    const localState = awareness.getLocalState();
+    const localState = e.awareness.getLocalState();
     const currentRange = localState?.[selectionStateField];
 
     if (!range) {
       if (currentRange) {
-        awareness.setLocalStateField(e.selectionStateField, null);
+        e.awareness.setLocalStateField(e.selectionStateField, null);
       }
 
       return;
@@ -199,7 +199,7 @@ export function withCursors<
       !Y.compareRelativePositions(anchor, currentRange) ||
       !Y.compareRelativePositions(focus, currentRange)
     ) {
-      awareness.setLocalStateField(e.selectionStateField, { anchor, focus });
+      e.awareness.setLocalStateField(e.selectionStateField, { anchor, focus });
     }
   };
 
@@ -233,7 +233,7 @@ export function withCursors<
 
     awarenessChangeListener({
       removed: [],
-      added: Array.from(awareness.getStates().keys()),
+      added: Array.from(e.awareness.getStates().keys()),
       updated: [],
     });
 
@@ -257,7 +257,7 @@ export function withCursors<
     e.awareness.off('change', awarenessChangeListener);
 
     awarenessChangeListener({
-      removed: Array.from(awareness.getStates().keys()),
+      removed: Array.from(e.awareness.getStates().keys()),
       added: [],
       updated: [],
     });

--- a/packages/core/src/plugins/withYHistory.ts
+++ b/packages/core/src/plugins/withYHistory.ts
@@ -120,7 +120,7 @@ export function withYHistory<T extends YjsEditor>(
   }) => {
     // TODO: Change once https://github.com/yjs/yjs/issues/353 is resolved
     const inverseStack =
-      type === 'undo' ? undoManager.redoStack : undoManager.undoStack;
+      type === 'undo' ? e.undoManager.redoStack : e.undoManager.undoStack;
     const inverseItem = inverseStack[inverseStack.length - 1];
     if (inverseItem) {
       inverseItem.meta.set('selection', stackItem.meta.get('selectionBefore'));
@@ -152,15 +152,15 @@ export function withYHistory<T extends YjsEditor>(
   e.connect = () => {
     connect();
 
-    undoManager.on('stack-item-added', handleStackItemAdded);
-    undoManager.on('stack-item-popped', handleStackItemPopped);
-    undoManager.on('stack-item-updated', handleStackItemUpdated);
+    e.undoManager.on('stack-item-added', handleStackItemAdded);
+    e.undoManager.on('stack-item-popped', handleStackItemPopped);
+    e.undoManager.on('stack-item-updated', handleStackItemUpdated);
   };
 
   e.disconnect = () => {
-    undoManager.off('stack-item-added', handleStackItemAdded);
-    undoManager.off('stack-item-popped', handleStackItemPopped);
-    undoManager.off('stack-item-updated', handleStackItemUpdated);
+    e.undoManager.off('stack-item-added', handleStackItemAdded);
+    e.undoManager.off('stack-item-popped', handleStackItemPopped);
+    e.undoManager.off('stack-item-updated', handleStackItemUpdated);
 
     disconnect();
   };


### PR DESCRIPTION
A few more fixes for editor properties usage in plugin's methods (like in #358)