### PR TITLE
Migrate from faker to @faker-js/faker for example

### DIFF
--- a/examples/frontend/package.json
+++ b/examples/frontend/package.json
@@ -9,6 +9,7 @@
     "deploy": "yarn netlify deploy --prod --dir ./dist"
   },
   "dependencies": {
+    "@faker-js/faker": "^7.5.0",
     "@fortawesome/fontawesome-svg-core": "^1.3.0",
     "@fortawesome/free-regular-svg-icons": "^6.0.0",
     "@fortawesome/free-solid-svg-icons": "^6.0.0",
@@ -17,7 +18,6 @@
     "@slate-yjs/core": "workspace:^",
     "@slate-yjs/react": "workspace:^",
     "clsx": "^1.1.1",
-    "faker": "^5.5.3",
     "randomcolor": "^0.6.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -27,7 +27,6 @@
     "yjs": "^13.5.29"
   },
   "devDependencies": {
-    "@types/faker": "^5.5.9",
     "@types/randomcolor": "^0",
     "@types/react": "^17.0.34",
     "@types/react-dom": "^17.0.11",

--- a/examples/frontend/src/utils.ts
+++ b/examples/frontend/src/utils.ts
@@ -1,6 +1,10 @@
-import { name } from 'faker';
+import { faker } from '@faker-js/faker';
 import randomColor from 'randomcolor';
 import { CursorData } from './types';
+
+const {
+  name: { firstName, lastName },
+} = faker;
 
 export function randomCursorData(): CursorData {
   return {
@@ -9,7 +13,7 @@ export function randomCursorData(): CursorData {
       alpha: 1,
       format: 'hex',
     }),
-    name: `${name.firstName()} ${name.lastName()}`,
+    name: `${firstName()} ${lastName()}`,
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1979,6 +1979,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@faker-js/faker@npm:^7.5.0":
+  version: 7.5.0
+  resolution: "@faker-js/faker@npm:7.5.0"
+  checksum: 6f2c48a8017d486eddfe2c3e0b743b810bcc948e5dbd1395c44a38471294584636f565cb081517ce90b634f50d8678d1d38d0f7b6b48b7d402e0a2602cf4f2d9
+  languageName: node
+  linkType: hard
+
 "@fortawesome/fontawesome-common-types@npm:^0.3.0":
   version: 0.3.0
   resolution: "@fortawesome/fontawesome-common-types@npm:0.3.0"
@@ -3125,6 +3132,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@slate-yjs/example@workspace:examples/frontend"
   dependencies:
+    "@faker-js/faker": ^7.5.0
     "@fortawesome/fontawesome-svg-core": ^1.3.0
     "@fortawesome/free-regular-svg-icons": ^6.0.0
     "@fortawesome/free-solid-svg-icons": ^6.0.0
@@ -3132,14 +3140,12 @@ __metadata:
     "@hocuspocus/provider": ^1.0.0-alpha.36
     "@slate-yjs/core": "workspace:^"
     "@slate-yjs/react": "workspace:^"
-    "@types/faker": ^5.5.9
     "@types/randomcolor": ^0
     "@types/react": ^17.0.34
     "@types/react-dom": ^17.0.11
     "@vitejs/plugin-react": ^1.0.7
     autoprefixer: ^10.4.0
     clsx: ^1.1.1
-    faker: ^5.5.3
     netlify-cli: ^8.6.0
     randomcolor: ^0.6.2
     react: ^17.0.2
@@ -3296,13 +3302,6 @@ __metadata:
   version: 0.0.39
   resolution: "@types/estree@npm:0.0.39"
   checksum: 412fb5b9868f2c418126451821833414189b75cc6bf84361156feed733e3d92ec220b9d74a89e52722e03d5e241b2932732711b7497374a404fad49087adc248
-  languageName: node
-  linkType: hard
-
-"@types/faker@npm:^5.5.9":
-  version: 5.5.9
-  resolution: "@types/faker@npm:5.5.9"
-  checksum: c2cbd082abe29047c89cf29b86257e582d2a177a9d1ed3abf99aa1cc025d5e8a3d201dfaddf8441bfcc57ed43e4da80e666951e1c23a5b759ac441a5855b5c36
   languageName: node
   linkType: hard
 
@@ -7796,13 +7795,6 @@ __metadata:
     snapdragon: ^0.8.1
     to-regex: ^3.0.1
   checksum: a41531b8934735b684cef5e8c5a01d0f298d7d384500ceca38793a9ce098125aab04ee73e2d75d5b2901bc5dddd2b64e1b5e3bf19139ea48bac52af4a92f1d00
-  languageName: node
-  linkType: hard
-
-"faker@npm:^5.5.3":
-  version: 5.5.3
-  resolution: "faker@npm:5.5.3"
-  checksum: 684fd64c8d3897e54248f95b4f6319f75d97691b8500cd13adf4af2c28f9204f766c1d1aaa6b41338f0beaaa87256c3132f8708a1a8f189d122b92f6b98081c3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Since [faker](https://www.npmjs.com/package/faker) is now deprecated, it's better to migrate to [@faker-js/faker
](https://www.npmjs.com/package/@faker-js/faker)