### PR TITLE
Directly normalize editor on connect instead of calling onChange

### DIFF
--- a/.changeset/rotten-months-impress.md
+++ b/.changeset/rotten-months-impress.md
@@ -1,0 +1,5 @@
+---
+'@slate-yjs/core': patch
+---
+
+Normalize editor on connect to avoid rendering denormalized state

--- a/packages/core/src/plugins/withYjs.ts
+++ b/packages/core/src/plugins/withYjs.ts
@@ -210,7 +210,11 @@ export function withYjs<T extends Editor>(
     const content = yTextToSlateElement(e.sharedRoot);
     e.children = content.children;
     CONNECTED.add(e);
-    e.onChange();
+
+    Editor.normalize(editor, { force: true });
+    if (!editor.operations.length) {
+      editor.onChange();
+    }
   };
 
   e.disconnect = () => {


### PR DESCRIPTION
Enhances the behavior when initializing the editor with a non-empty shared root to avoid rendering a denormalized state