### PR TITLE
Fixed useUnsetCursorPositionOnBlur not hiding cursors.

### DIFF
--- a/packages/react/src/hooks/useRemoteCursorStateStore.ts
+++ b/packages/react/src/hooks/useRemoteCursorStateStore.ts
@@ -52,7 +52,7 @@ function createRemoteCursorStateStore<
 
     changed.forEach((clientId) => {
       const state = CursorEditor.cursorState(editor, clientId);
-      if (state === null) {
+      if (state === null || state.relativeSelection === null) {
         delete cursors[clientId.toString()];
         return;
       }


### PR DESCRIPTION
`useUnsetCursorPositionOnBlur` does not hide cursors when the remote editor blurs. This happens because `useUnsetCursorPositionOnBlur` only sets the cursor state field to `null` on blur, but does not set the client data field to `null`, which prevents the client from being deleted from the awareness state. 

One possible fix is to delete both fields on blur. 

Another possible fix (this PR) is to remove the cursor if the selection range gets deleted.