### PR TITLE
Ignore retain updates for XmlText

### DIFF
--- a/.changeset/neat-rabbits-tell.md
+++ b/.changeset/neat-rabbits-tell.md
@@ -1,0 +1,5 @@
+---
+'@slate-yjs/core': minor
+---
+
+ignore formatting attributes for non-text

--- a/packages/core/src/applyToSlate/textEvent.ts
+++ b/packages/core/src/applyToSlate/textEvent.ts
@@ -46,16 +46,20 @@ function applyDelta(node: Element, slatePath: Path, delta: Delta): Operation[] {
         const child = node.children[pathOffset];
         const childPath = [...slatePath, pathOffset];
 
+        if (!Text.isText(child)) {
+          // Ignore attribute updates on non-text nodes (which are backed by Y.XmlText)
+          // to be consistent with deltaInsertToSlateNode. Y.XmlText attributes don't show
+          // up in deltas but in key changes (YEvent.changes.keys).
+          continue;
+        }
+
         const newProperties = change.attributes;
         const properties = pick(
           node,
           ...(Object.keys(change.attributes) as Array<keyof Element>)
         );
 
-        if (
-          Text.isText(child) &&
-          (pathOffset === startPathOffset || pathOffset === endPathOffset)
-        ) {
+        if (pathOffset === startPathOffset || pathOffset === endPathOffset) {
           const start = pathOffset === startPathOffset ? startTextOffset : 0;
           const end =
             pathOffset === endPathOffset ? endTextOffset : child.text.length;


### PR DESCRIPTION
Updates applyToSlate to ignore retain attributes that correspond with XmlText nodes. We already ignore insert attributes for XmlText nodes so should do the same for retains for consistency:

https://github.com/BitPhinix/slate-yjs/blob/966b9325ff312058023d017f857fbb6ac9a7a8a4/packages/core/src/utils/convert.ts#L17-L23

XmlText do have attributes but these are different from the attributes on inserts and retains

1. insert and retain attributes are "formatting" attributes that are set by XmlText#format or XmlText#insert (and apply to the children of the XmlText)
2. XmlText attributes are set by XmlText#setAttribute and unaffected by formatting (even if XmlText is nested underneath XmlText)

We still use and update the second kind of attribute:

- https://github.com/BitPhinix/slate-yjs/blob/main/packages/core/src/utils/convert.ts#L14
- https://github.com/BitPhinix/slate-yjs/blob/main/packages/core/src/applyToSlate/textEvent.ts#L231

Initially I thought this was a Yjs issue so there is some more context here: https://github.com/yjs/yjs/issues/529. A big part of the problem is that if you have a mixture of text and XmlText underneath a node, formatting attributes that were only ever applied to the text can show up in retain attributes that apply to non-text. This results in non-text nodes in the Slate tree getting nonsensical text attributes.




