### PR TITLE
Fix assoc calculation when creating relative position

### DIFF
--- a/.changeset/nice-toys-return.md
+++ b/.changeset/nice-toys-return.md
@@ -1,0 +1,5 @@
+---
+'@slate-yjs/core': minor
+---
+
+Fix assoc calculation when creating relative position from a Slate point

--- a/packages/core/src/utils/position.ts
+++ b/packages/core/src/utils/position.ts
@@ -24,10 +24,11 @@ export function slatePointToRelativePosition(
     );
   }
 
+  const index = textRange.start + point.offset;
   return Y.createRelativePositionFromTypeIndex(
     yParent,
-    textRange.start + point.offset,
-    point.offset === textRange.end ? -1 : 0
+    index,
+    index === textRange.end ? -1 : 0
   );
 }
 


### PR DESCRIPTION
Updates `slatePointToRelativePosition` to take into account the text range start when determining whether to left-associate the position. The index used to calculate the relative position's association should be the same index provided to the relative position.

Encountered this issue when using undo/redo with `withYHistory`. When the previous cursor position was immediately before a void element, the cursor would fail to update on undo, as the position would be right-associated with the void element rather than left-associated with the end of the text node which preceded it.