### PR TITLE
[Documentation] missing brackets in useMemo fixed

### DIFF
--- a/docs/walkthroughs/installation.md
+++ b/docs/walkthroughs/installation.md
@@ -202,7 +202,7 @@ const Editor = () => {
         { at: [0] }
       );
     };
-  });
+  }, []);
 
   const [value, setValue] = useState([])
 


### PR DESCRIPTION
missing brackets added to the missing example in the documentation