### PR TITLE
name replaced by person as deprecated

### DIFF
--- a/examples/frontend/src/utils.ts
+++ b/examples/frontend/src/utils.ts
@@ -3,7 +3,7 @@ import randomColor from 'randomcolor';
 import { CursorData } from './types';
 
 const {
-  name: { firstName, lastName },
+  person: { firstName, lastName },
 } = faker;
 
 export function randomCursorData(): CursorData {


### PR DESCRIPTION
faker.name is deprecated since v8.0 and will be removed in v10.0.
It is replaced by faker.person