### PR TITLE
fix cursors overlay crash

### DIFF
--- a/.changeset/clean-pianos-turn.md
+++ b/.changeset/clean-pianos-turn.md
@@ -1,0 +1,5 @@
+---
+'@slate-yjs/react': minor
+---
+
+Add error handling to cursor overlay

--- a/.changeset/dirty-camels-poke.md
+++ b/.changeset/dirty-camels-poke.md
@@ -1,5 +1,5 @@
 ---
-"@slate-yjs/core": patch
+'@slate-yjs/core': patch
 ---
 
-fix: remove unnecessary assertion
+chore: remove unnecessary assertion

--- a/packages/react/src/utils/getCursorRange.ts
+++ b/packages/react/src/utils/getCursorRange.ts
@@ -28,13 +28,17 @@ export function getCursorRange<
 
   let range = cursorStates.get(cursorState);
   if (range === undefined) {
-    range = relativeRangeToSlateRange(
-      editor.sharedRoot,
-      editor,
-      cursorState.relativeSelection
-    );
+    try {
+      range = relativeRangeToSlateRange(
+        editor.sharedRoot,
+        editor,
+        cursorState.relativeSelection
+      );
 
-    cursorStates.set(cursorState, range);
+      cursorStates.set(cursorState, range);
+    } catch (e) {
+      return null;
+    }
   }
 
   return range;

--- a/packages/react/src/utils/getOverlayPosition.ts
+++ b/packages/react/src/utils/getOverlayPosition.ts
@@ -1,6 +1,6 @@
 import { BaseRange, Editor, Path, Range, Text } from 'slate';
 import { ReactEditor } from 'slate-react';
-import { reactEditorToDomRangeSafe } from "./react-editor-to-dom-range-safe";
+import { reactEditorToDomRangeSafe } from './react-editor-to-dom-range-safe';
 
 export type SelectionRect = {
   width: number;

--- a/packages/react/src/utils/getOverlayPosition.ts
+++ b/packages/react/src/utils/getOverlayPosition.ts
@@ -1,5 +1,6 @@
 import { BaseRange, Editor, Path, Range, Text } from 'slate';
 import { ReactEditor } from 'slate-react';
+import { reactEditorToDomRangeSafe } from "./react-editor-to-dom-range-safe";
 
 export type SelectionRect = {
   width: number;
@@ -31,7 +32,13 @@ export function getOverlayPosition(
   { yOffset, xOffset, shouldGenerateOverlay }: GetSelectionRectsOptions
 ): OverlayPosition {
   const [start, end] = Range.edges(range);
-  const domRange = ReactEditor.toDOMRange(editor, range);
+  const domRange = reactEditorToDomRangeSafe(editor, range);
+  if (!domRange) {
+    return {
+      caretPosition: null,
+      selectionRects: [],
+    };
+  }
 
   const selectionRects: SelectionRect[] = [];
   const nodeIterator = Editor.nodes(editor, {

--- a/packages/react/src/utils/react-editor-to-dom-range-safe.ts
+++ b/packages/react/src/utils/react-editor-to-dom-range-safe.ts
@@ -1,0 +1,13 @@
+import { ReactEditor } from 'slate-react';
+import { BaseRange } from 'slate';
+
+export function reactEditorToDomRangeSafe(
+  editor: ReactEditor,
+  range: BaseRange
+): Range | null {
+  try {
+    return ReactEditor.toDOMRange(editor, range);
+  } catch (e) {
+    return null;
+  }
+}


### PR DESCRIPTION
Hello @BitPhinix I made a temporary solution that seems to fix cursor crashes and they work as they should. It is clear that this is not a targeted solution, but at the moment I think it's better than not being able to use them at all in react 18. #372 