### PR TITLE
yTextToSlateElement strips properties from empty text nodes

### DIFF
--- a/packages/core/src/utils/convert.ts
+++ b/packages/core/src/utils/convert.ts
@@ -10,8 +10,9 @@ export function yTextToSlateElement(yText: Y.XmlText): Element {
   const children =
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     delta.length > 0 ? delta.map(deltaInsertToSlateNode) : [{ text: '' }];
+  const attributes = yText.getAttributes();
 
-  return { ...yText.getAttributes(), children };
+  return { ...attributes, children };
 }
 
 export function deltaInsertToSlateNode(insert: DeltaInsert): Node {

--- a/packages/core/test/index.test.ts
+++ b/packages/core/test/index.test.ts
@@ -10,7 +10,7 @@ export type FixtureModule = {
   module: {
     input: Editor;
     expected: Editor;
-    run: (e: Editor) => void;
+    run: (e: Editor) => any;
   };
 };
 
@@ -60,6 +60,14 @@ async function runCollaborationTest({ module }: FixtureModule) {
   expect(editor.children).toEqual(expectedEditor.children);
 }
 
+async function runUnitTest({ module }: FixtureModule) {
+  const { input, run, expected } = module;
+  const editor = await withTestingElements(input);
+  const runOutput = run(editor);
+  expect(runOutput).toEqual(expected);
+}
+
 describe('adapter', () => {
+  fixtures(__dirname, 'unit', runUnitTest);
   fixtures(__dirname, 'collaboration', runCollaborationTest);
 });

--- a/packages/core/test/unit/yTextToSlate.tsx
+++ b/packages/core/test/unit/yTextToSlate.tsx
@@ -1,0 +1,27 @@
+/** @jsx jsx */
+import { Editor } from 'slate';
+import { jsx } from '../../../../support/jsx';
+import { YjsEditor, yTextToSlateElement } from '../../src';
+
+export const input = (
+  <editor>
+    <unstyled>
+      <text bold />
+    </unstyled>
+  </editor>
+);
+
+export const expected = {
+  children: [
+    <unstyled>
+      <text bold />
+    </unstyled>,
+  ],
+};
+
+export function run(editor: Editor) {
+  const isYJSEditor = YjsEditor.isYjsEditor(editor);
+  if (!isYJSEditor) return;
+
+  return yTextToSlateElement(editor.sharedRoot);
+}


### PR DESCRIPTION
It seems `yTextToSlateElement` strips properties/marks from empty text nodes.  This causes issues b/c, when [editor.connect](https://github.com/BitPhinix/slate-yjs/blob/69f3e0eaecc0b81049dc57e70403df60e7a10163/packages/core/src/plugins/withYjs.ts#L210C1-L211C35) is called it   sets the output of `yTextToSlateElement` to `editor.children` [here](https://github.com/BitPhinix/slate-yjs/blob/69f3e0eaecc0b81049dc57e70403df60e7a10163/packages/core/src/plugins/withYjs.ts#L211C1-L211C35).

Stripping properties from empty text nodes results in information loss and bugs (we are experiencing a bug at [Aline](https://aline.co)).