### PR TITLE
Fix `getStoredPositions`

### DIFF
--- a/.changeset/silver-gorillas-lay.md
+++ b/.changeset/silver-gorillas-lay.md
@@ -1,0 +1,5 @@
+---
+"@slate-yjs/core": patch
+---
+
+Fix `getStoredPositions` decoding

--- a/packages/core/src/utils/position.ts
+++ b/packages/core/src/utils/position.ts
@@ -99,7 +99,7 @@ export function getStoredPositions(
       .filter(([key]) => key.startsWith(STORED_POSITION_PREFIX))
       .map(([key, position]) => [
         key.slice(STORED_POSITION_PREFIX.length),
-        Y.createRelativePositionFromJSON(position),
+        Y.decodeRelativePosition(position),
       ])
   );
 }


### PR DESCRIPTION
The current implementation tries to create the `RelativePosition` from JSON, however the passed-in argument is a Uint8Array rather than JSON. I replaced the call with `Y.decodeRelativePosition`.